### PR TITLE
Refactor progress bars

### DIFF
--- a/index.html
+++ b/index.html
@@ -33,20 +33,18 @@
       border-radius: 20px 0 0 20px;
       transition: width 0.4s;
     }
-    #progress-text {
+    .progress-segment {
       position: absolute;
-      left: 50%;
       top: 0;
-      transform: translateX(-50%);
-      font-size: 0.95rem;
-      color: #333;
-      line-height: 24px;
-      z-index: 2;
+      bottom: 0;
+      transition: width 0.4s, left 0.4s;
     }
-    #global-progress {
-      text-align: center;
-      margin-top: 0.5rem;
-      font-size: 0.9rem;
+    .progress-segment.known {
+      background: #4caf50;
+      left: 0;
+    }
+    .progress-segment.unknown {
+      background: #e53935;
     }
     main {
       display: flex;
@@ -181,11 +179,10 @@
     <div class="progress-container">
       <div class="progress-bar" id="progress-bar"></div>
     </div>
-    <p id="global-progress">Estudiado: 0/0 (0%)</p>
-    <div class="progress-container">
-      <div class="progress-bar" id="known-progress-bar"></div>
+    <div class="progress-container" id="overall-progress">
+      <div class="progress-segment known" id="segment-known"></div>
+      <div class="progress-segment unknown" id="segment-unknown"></div>
     </div>
-    <p id="known-progress">Comprendidos: 0/0 (0%)</p>
     <label class="toggle-container"><input type="checkbox" id="toggle-priority"> Priorizar no comprendidos</label>
   </header>
 
@@ -319,10 +316,9 @@
     // =================== ELEMENTOS DOM ===================
     const grid = document.getElementById('flashcards-grid');
     const progressBar = document.getElementById('progress-bar');
-    const knownProgressBar = document.getElementById('known-progress-bar');
+    const segmentKnown = document.getElementById('segment-known');
+    const segmentUnknown = document.getElementById('segment-unknown');
     const btnReload = document.getElementById('btn-reload');
-    const globalProgressText = document.getElementById('global-progress');
-    const knownProgressText = document.getElementById('known-progress');
     const togglePriority = document.getElementById('toggle-priority');
 
     // =================== FUNCIONES PRINCIPALES ===================
@@ -333,8 +329,7 @@
       togglePriority.addEventListener('change', () => {
         state.prioritizeUnknown = togglePriority.checked;
       });
-      showNewDeck();
-      updateKnownProgress();
+      updateGlobalProgress();
     }
 
     function loadFlashcards() {
@@ -342,18 +337,13 @@
     }
 
     function loadPersistentState() {
-      const seen = JSON.parse(localStorage.getItem('seenCards') || '[]');
-      const unknown = JSON.parse(localStorage.getItem('unknownCards') || '[]');
-      const counts = JSON.parse(localStorage.getItem('showCounts') || '{}');
-      state.seenCards = new Set(seen);
-      state.globalUnknown = new Set(unknown);
-      state.showCounts = counts;
+      state.seenCards = new Set();
+      state.globalUnknown = new Set();
+      state.showCounts = {};
     }
 
     function savePersistentState() {
-      localStorage.setItem('seenCards', JSON.stringify(Array.from(state.seenCards)));
-      localStorage.setItem('unknownCards', JSON.stringify(Array.from(state.globalUnknown)));
-      localStorage.setItem('showCounts', JSON.stringify(state.showCounts));
+      // Sin persistencia para reiniciar las barras en cada carga
     }
 
     function getRandomFlashcards(allCards, count, seed = null) {
@@ -424,7 +414,6 @@
       renderGrid();
       updateProgress();
       updateGlobalProgress();
-      updateKnownProgress();
     }
 
     function renderGrid() {
@@ -478,7 +467,6 @@
       }
       updateProgress();
       updateGlobalProgress();
-      updateKnownProgress();
     }
 
     function updateProgress() {
@@ -488,17 +476,15 @@
     }
 
     function updateGlobalProgress() {
-      const pct = Math.round((state.seenCards.size / state.allCards.length) * 100);
-      globalProgressText.textContent = `Estudiado: ${state.seenCards.size}/${state.allCards.length} (${pct}%)`;
+      const total = state.allCards.length;
+      const known = state.seenCards.size - state.globalUnknown.size;
+      const unknown = state.globalUnknown.size;
+      const knownPct = (known / total) * 100;
+      const unknownPct = (unknown / total) * 100;
+      segmentKnown.style.width = knownPct + '%';
+      segmentUnknown.style.left = knownPct + '%';
+      segmentUnknown.style.width = unknownPct + '%';
     }
-
-    function updateKnownProgress() {
-      const known = state.allCards.length - state.globalUnknown.size;
-      const pct = Math.round((known / state.allCards.length) * 100);
-      knownProgressBar.style.width = pct + '%';
-      knownProgressText.textContent = `Comprendidos: ${known}/${state.allCards.length} (${pct}%)`;
-    }
-
     btnReload.addEventListener('click', showNewDeck);
     window.addEventListener('DOMContentLoaded', initApp);
   </script>


### PR DESCRIPTION
## Summary
- remove text labels for progress info
- reset stored progress on load and disable persistence
- add color segments for overall progress bar
- allow starting with an empty deck so bars begin at zero

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6842b488510c832f96bca1a1442c9012