### PR TITLE
Initialize with first deck

### DIFF
--- a/index.html
+++ b/index.html
@@ -318,6 +318,7 @@
       togglePriority.addEventListener('change', () => {
         state.prioritizeUnknown = togglePriority.checked;
       });
+      showNewDeck();
       updateGlobalProgress();
     }
 


### PR DESCRIPTION
## Summary
- render a starting deck when the page initializes

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6842b8d00750832fadd34e19bb8abd00